### PR TITLE
0302 gf

### DIFF
--- a/masfactory/components/agents/agent.py
+++ b/masfactory/components/agents/agent.py
@@ -96,6 +96,10 @@ class Agent(Node):
     and output-field constraints, then runs iterative think/act cycles with optional tools.
     """
 
+    class Hook(Node.Hook):
+        THINK_COMPLETED = 'agent_think_completed'
+        ACT_COMPLETED = 'agent_act_completed'
+
     def __init__(self,
         name: str,
         instructions: str | list[str],
@@ -595,6 +599,10 @@ class Agent(Node):
                     settings["tool_choice"] = "auto"
 
                 response: dict = self.think(messages, settings=settings)
+
+                # Hook: agent_think_completed
+                self.hooks.dispatch(self.Hook.THINK_COMPLETED, self, response, messages)
+
                 if response["type"] == ModelResponseType.CONTENT:
                     response_content = self._strip_thinking_blocks(response["content"])
                     response_content_dict = self._out_formatter.format(response_content)
@@ -614,6 +622,9 @@ class Agent(Node):
 
                 tool_calls = response["content"]
                 tool_results = self.act(tool_calls)
+
+                # Hook: agent_act_completed
+                self.hooks.dispatch(self.Hook.ACT_COMPLETED, self, tool_calls, tool_results)
 
                 # Preserve existing behavior: append the raw assistant tool-call message
                 # when available (OpenAI), then append tool results.


### PR DESCRIPTION
### Title
`feat(agent): add fine-grained intermediate state hooks (THINK_COMPLETED, ACT_COMPLETED)`

### Description

**Motivation**
The current `Agent` node encapsulates complex "think" and "act" interaction logic within its `step` loop. To enhance workflow observability and support advanced research scenarios (such as Process Reward Evaluation, fine-grained credit assignment, and observation space construction in reinforcement learning), this PR introduces fine-grained intermediate step hooks.

**Changes**
- Expanded the Agent's Hook system in `masfactory/components/agents/agent.py`.
- Added a new `Agent.Hook` class that **inherits from `Node.Hook`**, maintaining a unified namespace for lifecycle events.
- Injected the `THINK_COMPLETED` hook: Dispatched after the model completes its `think` generation (but before parsing or tool execution), exposing the raw `response` and context `messages`.
- Injected the `ACT_COMPLETED` hook: Dispatched after the model completes the tool calling `act` phase, exposing the `tool_calls` arguments and the execution `tool_results`.

**Compatibility**
- **Fully backward compatible**. It reuses the underlying `HookManager` logic in `masfactory/utils/hook.py` without introducing any breaking changes to the core `Node` or graph engine base classes.
- External users can seamlessly continue using `agent.hook_register()` to listen to these newly added events.

### Usage Example
```python
# Listen for the completion of the model's thinking phase (e.g., to capture <think> tag content)
def on_think_completed(agent, response, messages):
    print(f"[{agent.name}] Thinking completed, response type: {response['type']}")

# Listen for tool call results
def on_act_completed(agent, tool_calls, tool_results):
    print(f"[{agent.name}] Tool execution finished, called {len(tool_calls)} tools")

agent.hook_register(Agent.Hook.THINK_COMPLETED, on_think_completed)
agent.hook_register(Agent.Hook.ACT_COMPLETED, on_act_completed)