### PR TITLE
Add Sparse MAD reproduction application

### DIFF
--- a/applications/sparse_mad_reproduction/.gitignore
+++ b/applications/sparse_mad_reproduction/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+.pytest_cache/
+.env
+*.pyc

--- a/applications/sparse_mad_reproduction/README.md
+++ b/applications/sparse_mad_reproduction/README.md
@@ -1,0 +1,256 @@
+﻿# 基于 MASFactory 的 Sparse MAD 论文复现示例
+
+本示例基于 MASFactory 的图工作流抽象，复现论文 **Improving Multi-Agent Debate with Sparse Communication Topology** 的核心方法。
+
+本项目的目标不是完全复现论文中的所有数值结果，而是展示如何将一篇多智能体算法论文抽象为 MASFactory 的 Node / Edge / Graph 工作流，并运行全连接多智能体辩论与稀疏通信多智能体辩论的对比实验，观察 accuracy 与估算输入 token 成本之间的关系。
+
+## 示例内容
+
+论文研究的是 Multi-Agent Debate, MAD 中的通信拓扑问题。传统 MAD 通常采用全连接通信方式：在后续辩论轮次中，每个 Agent 都能看到其他所有 Agent 的上一轮回答。这样做可能提升推理质量，但会显著增加输入上下文长度和 token 成本。
+
+Sparse MAD 则限制每个 Agent 只能看到部分邻居 Agent 的回答，从而降低通信成本。
+
+本项目将论文方法实现为如下流程：
+
+```text
+1. 构建通信拓扑 G = (V, E)
+2. 第 1 轮：每个 Agent 独立回答问题
+3. 第 2..N 轮：每个 Agent 只读取拓扑允许可见的上一轮回答
+4. 对所有 Agent 的最终答案进行多数投票
+5. 比较 accuracy 与估算输入 token 成本
+```
+
+## MASFactory 抽象方式
+
+本项目提供两个互补的图视角。
+
+### 实验 SOP 图
+
+在 VS Code 中使用 MASFactory Visualizer 打开：
+
+```text
+sparse_mad/visual_workflow.py
+```
+
+查看函数：
+
+```python
+build_visual_comparison_graph(client=...)
+```
+
+该图将论文复现实验过程展示为 MASFactory 节点：
+
+```text
+entry
+  -> PrepareDataset
+  -> BuildFullTopology_D_equals_1
+  -> RunFullyConnectedMAD
+  -> BuildNeighborTopology
+  -> RunNeighborConnectedMAD
+  -> ComputeAccuracyAndCostSaving
+  -> FormatExperimentReport
+  -> exit
+```
+
+这些 MASFactory Edge 负责在节点间传递实验状态，例如 dataset、拓扑运行结果、accuracy、token cost 和 cost saving。
+
+### Agent 通信拓扑图
+
+打开：
+
+```text
+sparse_mad/agent_topology_hex_visual.py
+```
+
+查看函数：
+
+```python
+build_hex_topology_visual_graph()
+```
+
+该图直接展示论文中的通信拓扑：
+
+```text
+Full_Agent_1..6: 全连接图 K6
+Neighbor_Agent_1..6: 环形邻居图 C6
+```
+
+在这个视角中：
+
+```text
+Agent = Node
+Agent 之间的通信关系 = Edge
+```
+
+MASFactory 的 RootGraph 是有向无环图，因此可视化文件中使用有向边展示论文中的无向通信关系。箭头方向仅用于 Visualizer 展示，不表示论文方法只能单向通信。
+
+## 项目结构
+
+```text
+sparse_mad/
+  topology.py                  # 构建全连接拓扑和邻居/环形拓扑
+  llm_runner.py                # 真实 LLM 多智能体辩论执行器
+  dry_runner.py                # 无 API 的确定性模拟执行器，用于测试和 demo
+  voting.py                    # 多数投票
+  metrics.py                   # 答案归一化、accuracy 判断、token 成本估算
+  experiment.py                # 全连接拓扑 vs 稀疏拓扑实验对比
+  workflow.py                  # 可执行 MASFactory RootGraph 封装
+  visual_workflow.py           # SOP 层级的可视化图
+  agent_topology_hex_visual.py # 静态 6-Agent 通信拓扑可视化
+  hf_datasets.py               # GSM8K、Hendrycks MATH、DeepMind Mathematics 数据加载
+examples/
+  compare_topologies.py        # 主实验命令行入口
+  run_dry_demo.py              # 无 API 快速 demo
+  run_llm_demo.py              # 单次真实 LLM 辩论 demo
+  run_visual_workflow.py       # 运行可视化 SOP 工作流
+tests/                         # 单元测试与工作流测试
+```
+
+## 安装依赖
+
+Windows PowerShell：
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements.txt
+```
+
+macOS / Linux：
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
+```
+
+## 配置模型 API
+
+真实 LLM 示例使用 OpenAI-compatible SDK。请通过环境变量配置密钥，不要把 API key 写入代码。
+
+Windows PowerShell：
+
+```powershell
+$env:OPENAI_API_KEY="your_api_key_here"
+$env:OPENAI_MODEL_NAME="gpt-4o-mini"
+# 可选：仅当使用第三方 OpenAI-compatible 网关时设置
+$env:OPENAI_BASE_URL="https://your-compatible-endpoint/v1"
+```
+
+为了兼容早期本地脚本，如果没有设置 `OPENAI_MODEL_NAME`，程序也会读取 `MODEL_NAME`。
+
+## 运行无 API Demo
+
+```powershell
+python examples\run_dry_demo.py
+```
+
+该命令不会调用外部模型，用于快速验证拓扑构造、稀疏邻居可见性、辩论轮次和多数投票流程。
+
+## 对比全连接 MAD 与稀疏 MAD
+
+运行内置 toy 数据集：
+
+```powershell
+python examples\compare_topologies.py --dataset mini_math --limit 20 --num-agents 4 --max-rounds 2
+```
+
+运行 GSM8K：
+
+```powershell
+python examples\compare_topologies.py --hf-dataset gsm8k --limit 50 --num-agents 6 --max-rounds 5
+```
+
+运行 Hendrycks MATH：
+
+```powershell
+python examples\compare_topologies.py --hf-dataset math --math-subset algebra --limit 50 --num-agents 6 --max-rounds 5
+```
+
+当简单数据集上两种拓扑都达到 100% accuracy 时，推荐运行更难的 Hendrycks MATH Level 5 压测：
+
+```powershell
+python examples\compare_topologies.py --hf-dataset math --math-subset intermediate_algebra --math-level 5 --shuffle --seed 42 --limit 50 --num-agents 6 --max-rounds 5
+```
+
+运行 DeepMind Mathematics Dataset，该数据集更接近论文 text reasoning 方向中的数学推理设置：
+
+```powershell
+python examples\compare_topologies.py --hf-dataset deepmind_math --dm-math-category algebra__linear_1d_composed --limit 100 --num-agents 6 --max-rounds 5
+```
+
+脚本会输出全连接拓扑的 accuracy / cost、稀疏邻居拓扑的 accuracy / cost，以及相对 cost saving。
+
+常用数据集参数：
+
+```text
+--math-level 5       将 Hendrycks MATH 过滤到最难等级
+--shuffle --seed 42  在应用 --limit 之前随机打乱样本，并保证可复现
+--limit N            控制实验规模和 API 成本
+```
+
+建议先用 `--limit 10` 或 `--limit 30` 快速试跑。对于 100 个样本、6 个 Agent、5 轮辩论的实验，总模型调用次数约为：
+
+```text
+2 * 100 * 6 * 5 = 6000
+```
+
+因此，`--limit 100` 更适合作为最终实验，而不是第一次 smoke test。
+
+## 实验结果解读
+
+主要输出格式如下：
+
+```text
+Fully-connected accuracy=..., cost=...
+Neighbor-connected accuracy=..., cost=...
+Sparse cost saving: ...
+```
+
+其中，`accuracy` 表示多数投票后的最终答案是否与数据集标准答案一致；`cost` 是估算输入 token 数，用于比较不同通信拓扑的相对成本；`Sparse cost saving` 计算方式为：
+
+```text
+1 - sparse_cost / fully_connected_cost
+```
+
+以下是在 DeepMind Mathematics `algebra__linear_1d_composed` 上运行 50 个样本、6 个 Agent、5 轮辩论得到的示例结果：
+
+```text
+Fully-connected MAD (D=1)
+  accuracy: 1.000 (50/50)
+  estimated input tokens: 1246626
+
+Neighbor-connected MAD
+  accuracy: 1.000 (50/50)
+  estimated input tokens: 675438
+
+Sparse cost saving: 45.8%
+```
+
+该结果说明，本项目中的 MASFactory 工作流能够正确完成全连接通信拓扑与稀疏邻居通信拓扑的对比实验；同时，稀疏邻居拓扑能够明显降低估算输入 token 成本。在该实验中，稀疏通信节省了 45.8% 的估算输入 token。
+
+但是，该数据集子任务对当前测试模型来说过于简单，两种拓扑都达到了 100% accuracy。因此，这组实验存在明显的 ceiling effect，尚不能完全验证稀疏多智能体辩论在困难推理任务上的效能保持或提升能力。它主要验证了复现流程、MASFactory 图工作流实现，以及稀疏通信的 cost-saving 行为。
+
+若要更严格地评估 sparse debate 的有效性，建议使用更困难的 Hendrycks MATH Level 5 设置，并开启随机采样，例如 `intermediate_algebra`、`counting_and_probability` 或 `number_theory`。
+
+## 运行可视化工作流
+
+```powershell
+python examples\run_visual_workflow.py --hf-dataset deepmind_math --limit 10 --num-agents 6 --max-rounds 5
+```
+
+该命令可配合 MASFactory Visualizer 查看论文 SOP 图。
+
+## 运行测试
+
+```powershell
+python -m pytest tests
+```
+
+测试覆盖拓扑构造、多数投票、答案解析与归一化、数据集映射、dry runner、fake LLM runner、MASFactory workflow invoke，以及 Visualizer 专用图构造。
+
+## 关于复现结论的说明
+
+本示例是论文方法在 MASFactory 框架下的可运行复现，并不声称已经严格复现论文中的全部实验数值。若要达到论文级完整复现，还需要对齐原论文模型、数据采样方式、Agent 数量、辩论轮数、图密度、多次重复实验以及官方 token usage 统计方式。
+
+本项目中的实验主要用于展示论文方法、MASFactory 抽象方式，以及全连接通信与稀疏通信之间的 accuracy / cost trade-off。

--- a/applications/sparse_mad_reproduction/docs/reproduction_report.md
+++ b/applications/sparse_mad_reproduction/docs/reproduction_report.md
@@ -1,0 +1,174 @@
+﻿# 基于 MASFactory 的 Sparse Multi-Agent Debate 论文复现说明
+
+## 1. 论文方法概述
+
+复现论文为 **Improving Multi-Agent Debate with Sparse Communication Topology**。论文关注 Multi-Agent Debate, MAD 中的通信成本问题：传统 MAD 在辩论阶段通常让每个 Agent 看到其他所有 Agent 的上一轮回答，这种全连接通信可以提升推理质量，但会随着 Agent 数量和辩论轮数增加带来很高的输入 token 成本。
+
+论文提出将 Agent 间通信建模为图：
+
+```text
+G = (V, E)
+```
+
+其中 `V` 是 Agent 集合，`E` 是通信边。如果两个 Agent 之间存在边，则它们可以在辩论阶段参考对方上一轮回答。图密度定义为：
+
+```text
+D = 2|E| / (|V|(|V| - 1))
+```
+
+`D = 1` 表示全连接图。论文核心思想是：使用稀疏通信拓扑，让 Agent 只读取邻居回答，在尽量保持任务表现的同时降低输入上下文长度和成本。
+
+## 2. 论文标准流程
+
+论文中的 MAD 流程可抽象为三步：
+
+1. **Individual Response Generation**：第一轮所有 Agent 独立回答同一问题，不互相通信。
+2. **Multi-Agent Debate**：从第二轮开始，每个 Agent 根据通信拓扑读取允许可见的上一轮回答，并更新自己的答案。
+3. **Reaching Consensus**：最后收集所有 Agent 的最终答案，通过多数投票得到系统输出。
+
+全连接 MAD 和 Sparse MAD 的差异不在于 Agent 数量，而在于辩论阶段每个 Agent 可见的邻居集合。
+
+## 3. MASFactory Node / Edge / Graph 抽象
+
+本项目将论文方法拆成两个层次的 MASFactory 图。
+
+### 3.1 实验 SOP 图
+
+文件：`sparse_mad/visual_workflow.py`
+
+核心函数：
+
+```python
+build_visual_comparison_graph(client=...)
+```
+
+该图展示完整复现实验流程：
+
+```text
+entry
+  -> PrepareDataset
+  -> BuildFullTopology_D_equals_1
+  -> RunFullyConnectedMAD
+  -> BuildNeighborTopology
+  -> RunNeighborConnectedMAD
+  -> ComputeAccuracyAndCostSaving
+  -> FormatExperimentReport
+  -> exit
+```
+
+这些 MASFactory `Node` 表示实验步骤，MASFactory `Edge` 负责传递数据，例如 `dataset`、`num_agents`、`max_rounds`、两种拓扑的评测结果、`accuracy`、`token_cost` 和 `cost_saving`。
+
+### 3.2 Agent 通信拓扑图
+
+文件：`sparse_mad/agent_topology_hex_visual.py`
+
+核心函数：
+
+```python
+build_hex_topology_visual_graph()
+```
+
+该图直接展示论文通信结构：
+
+```text
+Full_Agent_1..6: 全连接拓扑 K6
+Neighbor_Agent_1..6: 环形邻居拓扑 C6
+```
+
+在这个视角中：
+
+```text
+Agent = Node
+Agent 间通信关系 = Edge
+```
+
+MASFactory 的 `RootGraph` 是有向无环图，因此可视化文件用有向边展示论文中的无向通信关系。箭头方向只服务于 Visualizer 展示，不表示论文方法只能单向通信。
+
+## 4. 代码模块说明
+
+- `sparse_mad/topology.py`：构建 `fully_connected` 和 `ring / neighbor_connected` 拓扑，输出 `agents`、`edges`、`neighbors` 和 `density`。
+- `sparse_mad/llm_runner.py`：执行真实 LLM 多智能体辩论。第一轮独立回答，后续轮次只读取 `topology.neighbors[agent]` 中允许可见的回答。
+- `sparse_mad/dry_runner.py`：无 API 的确定性模拟，用于快速验证图结构、轮次和投票流程。
+- `sparse_mad/voting.py`：多数投票，对应论文中的 consensus 阶段。
+- `sparse_mad/metrics.py`：答案归一化、正确率判断和输入 token 成本估算。
+- `sparse_mad/experiment.py`：对同一数据集分别运行全连接拓扑和邻居拓扑，并计算 `cost_saving = 1 - sparse_cost / full_cost`。
+- `sparse_mad/workflow.py`：将可执行实验封装成 MASFactory `RootGraph`。
+- `sparse_mad/hf_datasets.py`：接入 GSM8K、Hendrycks MATH 和 DeepMind Mathematics Dataset。
+
+论文 sparse communication 的关键实现落在 `llm_runner.py`：
+
+```python
+neighbor_responses={
+    neighbor: previous[neighbor]
+    for neighbor in topology.neighbors[agent]
+}
+```
+
+这保证每个 Agent 在辩论阶段只能看到拓扑允许的邻居回答。
+
+## 5. 实验验证
+
+工程测试覆盖：拓扑构造、多数投票、答案解析与归一化、Hugging Face 数据集字段映射、DeepMind Mathematics 数据读取、MASFactory Graph build / invoke、Visualizer 专用 Graph build、全连接与邻居拓扑比较逻辑。
+
+当前验证命令：
+
+```powershell
+python -m pytest tests
+```
+
+最近一次验证结果：
+
+```text
+32 passed
+```
+
+可运行的数据集入口包括：
+
+```powershell
+python examples\compare_topologies.py --dataset mini_math --limit 20 --num-agents 4 --max-rounds 2
+python examples\compare_topologies.py --hf-dataset gsm8k --limit 50 --num-agents 6 --max-rounds 5
+python examples\compare_topologies.py --hf-dataset math --math-subset algebra --limit 50 --num-agents 6 --max-rounds 5
+python examples\compare_topologies.py --hf-dataset deepmind_math --dm-math-category algebra__linear_1d_composed --limit 100 --num-agents 6 --max-rounds 5
+```
+
+其中 `deepmind_math` 默认优先读取 Hugging Face 转换后的 parquet 快照；如果不可用，则回退到 DeepMind 原始 `mathematics_dataset-v1.0.tar.gz` 数据。
+
+## 6. 运行方式
+
+安装依赖：
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements.txt
+```
+
+配置 OpenAI-compatible 模型：
+
+```powershell
+$env:OPENAI_API_KEY="your_api_key"
+$env:OPENAI_MODEL_NAME="gpt-4o-mini"
+# 可选：仅当使用第三方 OpenAI-compatible 网关时设置
+$env:OPENAI_BASE_URL="https://your-compatible-endpoint/v1"
+```
+
+运行无 API demo：
+
+```powershell
+python examples\run_dry_demo.py
+```
+
+运行真实 LLM 对比实验：
+
+```powershell
+python examples\compare_topologies.py --hf-dataset deepmind_math --limit 50 --num-agents 6 --max-rounds 5
+```
+
+## 7. 复现边界
+
+本项目已经完成论文方法在 MASFactory 框架下的可运行复现，并能验证稀疏通信降低输入上下文成本这一核心现象。但它不声称已经严格复现论文全部数值结果。
+
+若要达到论文级完整复现，还需要进一步对齐：原论文模型、采样策略、Agent 数量、辩论轮数、更多图密度、多次重复实验、MathVista / Anthropic-HH 等非文本或偏好任务，以及官方 token usage 统计方式。
+
+因此，本项目更适合作为 MASFactory 的研究复现示例：展示如何把论文 SOP 抽象为 Node / Edge / Graph，并用 MASFactory 执行和可视化多智能体算法。
+

--- a/applications/sparse_mad_reproduction/examples/compare_topologies.py
+++ b/applications/sparse_mad_reproduction/examples/compare_topologies.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sparse_mad.datasets import load_builtin_dataset, load_jsonl_dataset
+from sparse_mad.hf_datasets import DEFAULT_DEEPMIND_MATH_SUBSET, load_hf_dataset
+from sparse_mad.llm_runner import OpenAICompatibleClient
+from sparse_mad.workflow import build_sparse_mad_comparison_graph
+
+
+def main() -> None:
+    args = _parse_args()
+    dataset = _load_dataset(args)
+
+    client = OpenAICompatibleClient()
+    graph = build_sparse_mad_comparison_graph(client=client)
+    output, _attrs = graph.invoke(
+        {
+            "dataset": dataset,
+            "num_agents": args.num_agents,
+            "max_rounds": args.max_rounds,
+        }
+    )
+
+    print(output["summary"])
+    print()
+    _print_topology_result("Fully-connected MAD (D=1)", output["fully_connected"])
+    print()
+    _print_topology_result("Neighbor-connected MAD", output["neighbor_connected"])
+    print()
+    print(f"Sparse cost saving: {output['cost_saving']:.1%}")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare fully-connected MAD with neighbor-connected MAD.")
+    parser.add_argument("--dataset", default="mini_math", help="Built-in dataset name. Default: mini_math")
+    parser.add_argument("--dataset-path", help="Optional JSONL dataset path with question and answer fields.")
+    parser.add_argument(
+        "--hf-dataset",
+        choices=["gsm8k", "math", "hendrycks_math", "deepmind_math", "math_dataset"],
+        help="Load a paper reasoning dataset from Hugging Face.",
+    )
+    parser.add_argument("--split", default="test", help="Hugging Face split. Default: test")
+    parser.add_argument("--math-subset", default="algebra", help="Hendrycks MATH subset. Default: algebra")
+    parser.add_argument("--math-level", type=int, choices=[1, 2, 3, 4, 5], help="Optional Hendrycks MATH difficulty level filter.")
+    parser.add_argument(
+        "--deepmind-math-subset",
+        "--dm-math-category",
+        dest="deepmind_math_subset",
+        default=DEFAULT_DEEPMIND_MATH_SUBSET,
+        help=f"DeepMind Mathematics Dataset subset. Default: {DEFAULT_DEEPMIND_MATH_SUBSET}",
+    )
+    parser.add_argument("--shuffle", action="store_true", help="Shuffle samples before applying --limit.")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed used with --shuffle. Default: 42")
+    parser.add_argument("--limit", type=int, default=3, help="Number of samples to run. Default: 3")
+    parser.add_argument("--num-agents", type=int, default=4, help="Number of debate agents. Default: 4")
+    parser.add_argument("--max-rounds", type=int, default=2, help="Total debate rounds. Default: 2")
+    return parser.parse_args()
+
+
+def _load_dataset(args: argparse.Namespace) -> list[dict[str, str]]:
+    if args.hf_dataset:
+        return load_hf_dataset(
+            args.hf_dataset,
+            split=args.split,
+            limit=args.limit,
+            math_subset=args.math_subset,
+            math_level=args.math_level,
+            deepmind_math_subset=args.deepmind_math_subset,
+            shuffle=args.shuffle,
+            seed=args.seed,
+        )
+    if args.dataset_path:
+        return load_jsonl_dataset(args.dataset_path, limit=args.limit)
+    return load_builtin_dataset(args.dataset, limit=args.limit)
+
+
+def _print_topology_result(title: str, result: dict) -> None:
+    print(title)
+    print(f"  accuracy: {result['accuracy']:.3f} ({result['correct_count']}/{result['total_count']})")
+    print(f"  estimated input tokens: {result['token_cost']}")
+    for index, run in enumerate(result["runs"], start=1):
+        print(
+            f"  sample {index}: predicted={run['final_answer']} "
+            f"expected={run['expected_answer']} correct={run['correct']}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/applications/sparse_mad_reproduction/examples/run_dry_demo.py
+++ b/applications/sparse_mad_reproduction/examples/run_dry_demo.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sparse_mad.workflow import build_sparse_mad_dry_graph
+
+
+def main() -> None:
+    graph = build_sparse_mad_dry_graph()
+    output, _attrs = graph.invoke(
+        {
+            "question": "What is 20 + 22?",
+            "num_agents": 6,
+            "topology_type": "ring",
+            "max_rounds": 3,
+            "correct_answer": "42",
+        }
+    )
+
+    print(output["summary"])
+    print("\nTopology neighbors:")
+    for agent, neighbors in output["topology"]["neighbors"].items():
+        print(f"{agent}: {', '.join(neighbors)}")
+
+    print("\nFinal agent answers:")
+    for agent, answer in output["final_agent_answers"].items():
+        print(f"{agent}: {answer}")
+
+
+if __name__ == "__main__":
+    main()

--- a/applications/sparse_mad_reproduction/examples/run_llm_demo.py
+++ b/applications/sparse_mad_reproduction/examples/run_llm_demo.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sparse_mad.llm_runner import OpenAICompatibleClient
+from sparse_mad.workflow import build_sparse_mad_llm_graph
+
+
+def main() -> None:
+    client = OpenAICompatibleClient()
+    graph = build_sparse_mad_llm_graph(client=client)
+    output, _attrs = graph.invoke(
+        {
+            "question": "If a train travels 60 km in 1.5 hours, what is its average speed in km/h?",
+            "num_agents": 4,
+            "topology_type": "ring",
+            "max_rounds": 2,
+        }
+    )
+
+    print(output["summary"])
+    print("\nFinal agent answers:")
+    for agent, answer in output["final_agent_answers"].items():
+        print(f"{agent}: {answer}")
+
+    print("\nFinal-round reasoning:")
+    final_round = max(output["responses_by_round"])
+    for agent, response in output["responses_by_round"][final_round].items():
+        print(f"\n[{agent}]")
+        print(response["reasoning"])
+
+
+if __name__ == "__main__":
+    main()

--- a/applications/sparse_mad_reproduction/examples/run_visual_workflow.py
+++ b/applications/sparse_mad_reproduction/examples/run_visual_workflow.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sparse_mad.datasets import load_builtin_dataset, load_jsonl_dataset
+from sparse_mad.hf_datasets import DEFAULT_DEEPMIND_MATH_SUBSET, load_hf_dataset
+from sparse_mad.llm_runner import OpenAICompatibleClient
+from sparse_mad.visual_workflow import build_visual_comparison_graph
+
+
+def main() -> None:
+    args = _parse_args()
+    dataset = _load_dataset(args)
+    client = OpenAICompatibleClient()
+    graph = build_visual_comparison_graph(client=client)
+    output, _attrs = graph.invoke(
+        {
+            "dataset": dataset,
+            "num_agents": args.num_agents,
+            "max_rounds": args.max_rounds,
+        }
+    )
+    print(output["report"])
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the visual Sparse MAD comparison workflow.")
+    parser.add_argument("--dataset", default="mini_math")
+    parser.add_argument("--dataset-path")
+    parser.add_argument("--hf-dataset", choices=["gsm8k", "math", "hendrycks_math", "deepmind_math", "math_dataset"])
+    parser.add_argument("--split", default="test")
+    parser.add_argument("--math-subset", default="algebra")
+    parser.add_argument("--math-level", type=int, choices=[1, 2, 3, 4, 5])
+    parser.add_argument(
+        "--deepmind-math-subset",
+        "--dm-math-category",
+        dest="deepmind_math_subset",
+        default=DEFAULT_DEEPMIND_MATH_SUBSET,
+    )
+    parser.add_argument("--shuffle", action="store_true")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--limit", type=int, default=2)
+    parser.add_argument("--num-agents", type=int, default=4)
+    parser.add_argument("--max-rounds", type=int, default=2)
+    return parser.parse_args()
+
+
+def _load_dataset(args: argparse.Namespace) -> list[dict[str, str]]:
+    if args.hf_dataset:
+        return load_hf_dataset(
+            args.hf_dataset,
+            split=args.split,
+            limit=args.limit,
+            math_subset=args.math_subset,
+            math_level=args.math_level,
+            deepmind_math_subset=args.deepmind_math_subset,
+            shuffle=args.shuffle,
+            seed=args.seed,
+        )
+    if args.dataset_path:
+        return load_jsonl_dataset(args.dataset_path, limit=args.limit)
+    return load_builtin_dataset(args.dataset, limit=args.limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/applications/sparse_mad_reproduction/examples/show_agent_topology_visual.py
+++ b/applications/sparse_mad_reproduction/examples/show_agent_topology_visual.py
@@ -1,0 +1,20 @@
+﻿from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sparse_mad.agent_topology_visual import build_agent_topology_visual_graph, expected_edge_counts
+
+
+def main() -> None:
+    num_agents = 4
+    graph = build_agent_topology_visual_graph(num_agents=num_agents)
+    print(f"Built graph: {graph.name}")
+    print(expected_edge_counts(num_agents=num_agents))
+    print("Open sparse_mad/agent_topology_visual.py with MASFactory Visualizer to inspect explicit Agent nodes and topology edges.")
+
+
+if __name__ == "__main__":
+    main()

--- a/applications/sparse_mad_reproduction/examples/show_hex_topology_visual.py
+++ b/applications/sparse_mad_reproduction/examples/show_hex_topology_visual.py
@@ -1,0 +1,19 @@
+﻿from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sparse_mad.agent_topology_hex_visual import build_hex_topology_visual_graph, hex_edge_counts
+
+
+def main() -> None:
+    graph = build_hex_topology_visual_graph()
+    print(f"Built graph: {graph.name}")
+    print(hex_edge_counts())
+    print("Open sparse_mad/agent_topology_hex_visual.py with MASFactory Visualizer.")
+
+
+if __name__ == "__main__":
+    main()

--- a/applications/sparse_mad_reproduction/requirements.txt
+++ b/applications/sparse_mad_reproduction/requirements.txt
@@ -1,0 +1,4 @@
+﻿masfactory
+openai
+pytest
+datasets

--- a/applications/sparse_mad_reproduction/sparse_mad/__init__.py
+++ b/applications/sparse_mad_reproduction/sparse_mad/__init__.py
@@ -1,0 +1,2 @@
+"""Sparse multi-agent debate demo implemented with MASFactory-friendly modules."""
+

--- a/applications/sparse_mad_reproduction/sparse_mad/agent_topology_hex_visual.py
+++ b/applications/sparse_mad_reproduction/sparse_mad/agent_topology_hex_visual.py
@@ -1,0 +1,98 @@
+﻿from __future__ import annotations
+
+
+TOPOLOGY_INPUT_KEYS = {"question": "placeholder input for topology visualization"}
+TOPOLOGY_EDGE_KEYS = {"communication": "undirected communication relation represented by one edge"}
+SUMMARY_KEYS = {"visual_summary": "summary of full and neighbor topology graphs"}
+
+
+def build_hex_topology_visual_graph():
+    """Static 6-agent communication-topology graph for Visualizer.
+
+    This graph visualizes the paper topology itself, not the cross-round message
+    execution flow. Each Agent is a node. Each edge means the two agents can
+    see each other's previous-round answers. For visual clarity, each undirected
+    relation is represented with one directed MASFactory edge.
+    """
+    from masfactory import CustomNode, RootGraph
+
+    graph = RootGraph(name="hex_topology_visual_graph")
+
+    start = graph.create_node(CustomNode, name="TopologyInput", forward=_topology_input)
+
+    full_a1 = graph.create_node(CustomNode, name="Full_Agent_1", forward=_pass_communication)
+    full_a2 = graph.create_node(CustomNode, name="Full_Agent_2", forward=_pass_communication)
+    full_a3 = graph.create_node(CustomNode, name="Full_Agent_3", forward=_pass_communication)
+    full_a4 = graph.create_node(CustomNode, name="Full_Agent_4", forward=_pass_communication)
+    full_a5 = graph.create_node(CustomNode, name="Full_Agent_5", forward=_pass_communication)
+    full_a6 = graph.create_node(CustomNode, name="Full_Agent_6", forward=_pass_communication)
+
+    neighbor_a1 = graph.create_node(CustomNode, name="Neighbor_Agent_1", forward=_pass_communication)
+    neighbor_a2 = graph.create_node(CustomNode, name="Neighbor_Agent_2", forward=_pass_communication)
+    neighbor_a3 = graph.create_node(CustomNode, name="Neighbor_Agent_3", forward=_pass_communication)
+    neighbor_a4 = graph.create_node(CustomNode, name="Neighbor_Agent_4", forward=_pass_communication)
+    neighbor_a5 = graph.create_node(CustomNode, name="Neighbor_Agent_5", forward=_pass_communication)
+    neighbor_a6 = graph.create_node(CustomNode, name="Neighbor_Agent_6", forward=_pass_communication)
+
+    summary = graph.create_node(CustomNode, name="TopologySummary", forward=_summary)
+
+    graph.edge_from_entry(start, TOPOLOGY_INPUT_KEYS)
+
+    graph.create_edge(start, full_a1, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(start, neighbor_a1, TOPOLOGY_EDGE_KEYS)
+
+    # Full topology K6: every pair of agents is connected.
+    graph.create_edge(full_a1, full_a2, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(full_a1, full_a3, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(full_a1, full_a4, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(full_a1, full_a5, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(full_a1, full_a6, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(full_a2, full_a3, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(full_a2, full_a4, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(full_a2, full_a5, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(full_a2, full_a6, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(full_a3, full_a4, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(full_a3, full_a5, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(full_a3, full_a6, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(full_a4, full_a5, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(full_a4, full_a6, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(full_a5, full_a6, TOPOLOGY_EDGE_KEYS)
+
+    # Neighbor topology C6: only adjacent agents are connected in a ring.
+    graph.create_edge(neighbor_a1, neighbor_a2, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(neighbor_a2, neighbor_a3, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(neighbor_a3, neighbor_a4, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(neighbor_a4, neighbor_a5, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(neighbor_a5, neighbor_a6, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(neighbor_a1, neighbor_a6, TOPOLOGY_EDGE_KEYS)
+
+    graph.create_edge(full_a6, summary, TOPOLOGY_EDGE_KEYS)
+    graph.create_edge(neighbor_a6, summary, TOPOLOGY_EDGE_KEYS)
+    graph.edge_to_exit(summary, SUMMARY_KEYS)
+
+    graph.build()
+    return graph
+
+
+def hex_edge_counts() -> dict[str, int]:
+    return {
+        "fully_connected_edges": 15,
+        "neighbor_ring_edges": 6,
+    }
+
+
+def _topology_input(input_data: dict) -> dict:
+    return {"communication": "communication topology visualization"}
+
+
+def _pass_communication(input_data: dict) -> dict:
+    return {"communication": input_data.get("communication", "visible communication relation")}
+
+
+def _summary(input_data: dict) -> dict:
+    return {
+        "visual_summary": (
+            "Full topology is K6 with 15 undirected edges; "
+            "neighbor topology is C6 with 6 undirected ring edges."
+        )
+    }

--- a/applications/sparse_mad_reproduction/sparse_mad/agent_topology_static_visual.py
+++ b/applications/sparse_mad_reproduction/sparse_mad/agent_topology_static_visual.py
@@ -1,0 +1,177 @@
+﻿from __future__ import annotations
+
+
+QUESTION_KEYS = {"question": "input question for visualization"}
+RESPONSE_KEYS = {"visible_response": "previous-round response visible through this communication edge"}
+ANSWER_KEYS = {"agent_answer": "agent final answer for consensus"}
+FULL_RESULT_KEYS = {"full_result": "fully-connected consensus result"}
+NEIGHBOR_RESULT_KEYS = {"neighbor_result": "neighbor-connected consensus result"}
+SUMMARY_KEYS = {"visual_summary": "summary of the static topology visualization"}
+
+
+def build_static_agent_topology_graph():
+    """Static 4-agent topology graph for MASFactory Visualizer.
+
+    No loops are used here on purpose. The Visualizer can warn on dynamic graph
+    construction, so this file explicitly declares every node and edge.
+    """
+    from masfactory import CustomNode, RootGraph
+
+    graph = RootGraph(name="static_agent_topology_visual_graph")
+
+    prepare = graph.create_node(CustomNode, name="PrepareQuestion", forward=_prepare_question)
+
+    full_r1_a1 = graph.create_node(CustomNode, name="Full_R1_Agent_1", forward=_initial_full_a1)
+    full_r1_a2 = graph.create_node(CustomNode, name="Full_R1_Agent_2", forward=_initial_full_a2)
+    full_r1_a3 = graph.create_node(CustomNode, name="Full_R1_Agent_3", forward=_initial_full_a3)
+    full_r1_a4 = graph.create_node(CustomNode, name="Full_R1_Agent_4", forward=_initial_full_a4)
+
+    full_r2_a1 = graph.create_node(CustomNode, name="Full_R2_Agent_1", forward=_debate_full_a1)
+    full_r2_a2 = graph.create_node(CustomNode, name="Full_R2_Agent_2", forward=_debate_full_a2)
+    full_r2_a3 = graph.create_node(CustomNode, name="Full_R2_Agent_3", forward=_debate_full_a3)
+    full_r2_a4 = graph.create_node(CustomNode, name="Full_R2_Agent_4", forward=_debate_full_a4)
+    full_vote = graph.create_node(CustomNode, name="Full_ConsensusVote", forward=_full_vote)
+
+    neighbor_r1_a1 = graph.create_node(CustomNode, name="Neighbor_R1_Agent_1", forward=_initial_neighbor_a1)
+    neighbor_r1_a2 = graph.create_node(CustomNode, name="Neighbor_R1_Agent_2", forward=_initial_neighbor_a2)
+    neighbor_r1_a3 = graph.create_node(CustomNode, name="Neighbor_R1_Agent_3", forward=_initial_neighbor_a3)
+    neighbor_r1_a4 = graph.create_node(CustomNode, name="Neighbor_R1_Agent_4", forward=_initial_neighbor_a4)
+
+    neighbor_r2_a1 = graph.create_node(CustomNode, name="Neighbor_R2_Agent_1", forward=_debate_neighbor_a1)
+    neighbor_r2_a2 = graph.create_node(CustomNode, name="Neighbor_R2_Agent_2", forward=_debate_neighbor_a2)
+    neighbor_r2_a3 = graph.create_node(CustomNode, name="Neighbor_R2_Agent_3", forward=_debate_neighbor_a3)
+    neighbor_r2_a4 = graph.create_node(CustomNode, name="Neighbor_R2_Agent_4", forward=_debate_neighbor_a4)
+    neighbor_vote = graph.create_node(CustomNode, name="Neighbor_ConsensusVote", forward=_neighbor_vote)
+
+    compare = graph.create_node(CustomNode, name="CompareAccuracyAndCostSaving", forward=_compare)
+
+    graph.edge_from_entry(prepare, QUESTION_KEYS)
+
+    graph.create_edge(prepare, full_r1_a1, QUESTION_KEYS)
+    graph.create_edge(prepare, full_r1_a2, QUESTION_KEYS)
+    graph.create_edge(prepare, full_r1_a3, QUESTION_KEYS)
+    graph.create_edge(prepare, full_r1_a4, QUESTION_KEYS)
+    graph.create_edge(prepare, neighbor_r1_a1, QUESTION_KEYS)
+    graph.create_edge(prepare, neighbor_r1_a2, QUESTION_KEYS)
+    graph.create_edge(prepare, neighbor_r1_a3, QUESTION_KEYS)
+    graph.create_edge(prepare, neighbor_r1_a4, QUESTION_KEYS)
+
+    # Fully connected visibility: every R2 agent sees every other R1 agent.
+    graph.create_edge(full_r1_a1, full_r2_a2, RESPONSE_KEYS)
+    graph.create_edge(full_r1_a1, full_r2_a3, RESPONSE_KEYS)
+    graph.create_edge(full_r1_a1, full_r2_a4, RESPONSE_KEYS)
+    graph.create_edge(full_r1_a2, full_r2_a1, RESPONSE_KEYS)
+    graph.create_edge(full_r1_a2, full_r2_a3, RESPONSE_KEYS)
+    graph.create_edge(full_r1_a2, full_r2_a4, RESPONSE_KEYS)
+    graph.create_edge(full_r1_a3, full_r2_a1, RESPONSE_KEYS)
+    graph.create_edge(full_r1_a3, full_r2_a2, RESPONSE_KEYS)
+    graph.create_edge(full_r1_a3, full_r2_a4, RESPONSE_KEYS)
+    graph.create_edge(full_r1_a4, full_r2_a1, RESPONSE_KEYS)
+    graph.create_edge(full_r1_a4, full_r2_a2, RESPONSE_KEYS)
+    graph.create_edge(full_r1_a4, full_r2_a3, RESPONSE_KEYS)
+
+    # Neighbor-connected visibility on a 4-agent ring.
+    graph.create_edge(neighbor_r1_a1, neighbor_r2_a2, RESPONSE_KEYS)
+    graph.create_edge(neighbor_r1_a1, neighbor_r2_a4, RESPONSE_KEYS)
+    graph.create_edge(neighbor_r1_a2, neighbor_r2_a1, RESPONSE_KEYS)
+    graph.create_edge(neighbor_r1_a2, neighbor_r2_a3, RESPONSE_KEYS)
+    graph.create_edge(neighbor_r1_a3, neighbor_r2_a2, RESPONSE_KEYS)
+    graph.create_edge(neighbor_r1_a3, neighbor_r2_a4, RESPONSE_KEYS)
+    graph.create_edge(neighbor_r1_a4, neighbor_r2_a1, RESPONSE_KEYS)
+    graph.create_edge(neighbor_r1_a4, neighbor_r2_a3, RESPONSE_KEYS)
+
+    graph.create_edge(full_r2_a1, full_vote, ANSWER_KEYS)
+    graph.create_edge(full_r2_a2, full_vote, ANSWER_KEYS)
+    graph.create_edge(full_r2_a3, full_vote, ANSWER_KEYS)
+    graph.create_edge(full_r2_a4, full_vote, ANSWER_KEYS)
+    graph.create_edge(neighbor_r2_a1, neighbor_vote, ANSWER_KEYS)
+    graph.create_edge(neighbor_r2_a2, neighbor_vote, ANSWER_KEYS)
+    graph.create_edge(neighbor_r2_a3, neighbor_vote, ANSWER_KEYS)
+    graph.create_edge(neighbor_r2_a4, neighbor_vote, ANSWER_KEYS)
+
+    graph.create_edge(full_vote, compare, FULL_RESULT_KEYS)
+    graph.create_edge(neighbor_vote, compare, NEIGHBOR_RESULT_KEYS)
+    graph.edge_to_exit(compare, SUMMARY_KEYS)
+
+    graph.build()
+    return graph
+
+
+def _prepare_question(input_data: dict) -> dict:
+    return {"question": input_data.get("question", "static visualization")}
+
+
+def _initial_full_a1(input_data: dict) -> dict:
+    return {"visible_response": "Full Agent 1 round 1 answer"}
+
+
+def _initial_full_a2(input_data: dict) -> dict:
+    return {"visible_response": "Full Agent 2 round 1 answer"}
+
+
+def _initial_full_a3(input_data: dict) -> dict:
+    return {"visible_response": "Full Agent 3 round 1 answer"}
+
+
+def _initial_full_a4(input_data: dict) -> dict:
+    return {"visible_response": "Full Agent 4 round 1 answer"}
+
+
+def _initial_neighbor_a1(input_data: dict) -> dict:
+    return {"visible_response": "Neighbor Agent 1 round 1 answer"}
+
+
+def _initial_neighbor_a2(input_data: dict) -> dict:
+    return {"visible_response": "Neighbor Agent 2 round 1 answer"}
+
+
+def _initial_neighbor_a3(input_data: dict) -> dict:
+    return {"visible_response": "Neighbor Agent 3 round 1 answer"}
+
+
+def _initial_neighbor_a4(input_data: dict) -> dict:
+    return {"visible_response": "Neighbor Agent 4 round 1 answer"}
+
+
+def _debate_full_a1(input_data: dict) -> dict:
+    return {"agent_answer": "Full Agent 1 round 2 answer"}
+
+
+def _debate_full_a2(input_data: dict) -> dict:
+    return {"agent_answer": "Full Agent 2 round 2 answer"}
+
+
+def _debate_full_a3(input_data: dict) -> dict:
+    return {"agent_answer": "Full Agent 3 round 2 answer"}
+
+
+def _debate_full_a4(input_data: dict) -> dict:
+    return {"agent_answer": "Full Agent 4 round 2 answer"}
+
+
+def _debate_neighbor_a1(input_data: dict) -> dict:
+    return {"agent_answer": "Neighbor Agent 1 round 2 answer"}
+
+
+def _debate_neighbor_a2(input_data: dict) -> dict:
+    return {"agent_answer": "Neighbor Agent 2 round 2 answer"}
+
+
+def _debate_neighbor_a3(input_data: dict) -> dict:
+    return {"agent_answer": "Neighbor Agent 3 round 2 answer"}
+
+
+def _debate_neighbor_a4(input_data: dict) -> dict:
+    return {"agent_answer": "Neighbor Agent 4 round 2 answer"}
+
+
+def _full_vote(input_data: dict) -> dict:
+    return {"full_result": "Full topology consensus"}
+
+
+def _neighbor_vote(input_data: dict) -> dict:
+    return {"neighbor_result": "Neighbor topology consensus"}
+
+
+def _compare(input_data: dict) -> dict:
+    return {"visual_summary": "Static graph: full topology has 12 visibility edges; neighbor topology has 8."}

--- a/applications/sparse_mad_reproduction/sparse_mad/agent_topology_visual.py
+++ b/applications/sparse_mad_reproduction/sparse_mad/agent_topology_visual.py
@@ -1,0 +1,137 @@
+﻿from __future__ import annotations
+
+from collections.abc import Callable
+
+
+QUESTION_KEYS = {
+    "question": "input question for the debate demo",
+}
+
+RESPONSE_KEYS = {
+    "visible_response": "one previous-round response visible through a topology edge",
+}
+
+CONSENSUS_KEYS = {
+    "agent_answer": "final answer sent to consensus",
+}
+
+
+def build_agent_topology_visual_graph(*, num_agents: int = 4):
+    """Build a MASFactory graph whose edges directly visualize paper topologies.
+
+    This graph is intentionally visual-first: every debate agent is an explicit
+    node, and communication topology is represented by explicit edges from
+    round-1 agent nodes to round-2 agent nodes.
+    """
+    from masfactory import CustomNode, RootGraph
+
+    if num_agents < 3:
+        raise ValueError("num_agents must be at least 3 for neighbor topology visualization")
+
+    graph = RootGraph(name="agent_topology_visual_graph")
+
+    prepare = graph.create_node(CustomNode, name="PrepareQuestion", forward=_prepare_question)
+
+    full_initial = [
+        graph.create_node(
+            CustomNode,
+            name=f"Full_R1_Agent_{index}",
+            forward=_make_initial_forward(f"Full_R1_Agent_{index}"),
+        )
+        for index in range(1, num_agents + 1)
+    ]
+    full_debate = [
+        graph.create_node(
+            CustomNode,
+            name=f"Full_R2_Agent_{index}",
+            forward=_make_debate_forward(f"Full_R2_Agent_{index}"),
+        )
+        for index in range(1, num_agents + 1)
+    ]
+    full_vote = graph.create_node(CustomNode, name="Full_ConsensusVote", forward=_consensus_forward)
+
+    neighbor_initial = [
+        graph.create_node(
+            CustomNode,
+            name=f"Neighbor_R1_Agent_{index}",
+            forward=_make_initial_forward(f"Neighbor_R1_Agent_{index}"),
+        )
+        for index in range(1, num_agents + 1)
+    ]
+    neighbor_debate = [
+        graph.create_node(
+            CustomNode,
+            name=f"Neighbor_R2_Agent_{index}",
+            forward=_make_debate_forward(f"Neighbor_R2_Agent_{index}"),
+        )
+        for index in range(1, num_agents + 1)
+    ]
+    neighbor_vote = graph.create_node(CustomNode, name="Neighbor_ConsensusVote", forward=_consensus_forward)
+
+    compare = graph.create_node(CustomNode, name="CompareAccuracyAndCostSaving", forward=_compare_forward)
+
+    graph.edge_from_entry(prepare, QUESTION_KEYS)
+
+    for node in full_initial + neighbor_initial:
+        graph.create_edge(prepare, node, QUESTION_KEYS)
+
+    for source_index, source in enumerate(full_initial):
+        for target_index, target in enumerate(full_debate):
+            if source_index != target_index:
+                graph.create_edge(source, target, RESPONSE_KEYS)
+
+    for source_index, source in enumerate(neighbor_initial):
+        left_neighbor = (source_index - 1) % num_agents
+        right_neighbor = (source_index + 1) % num_agents
+        graph.create_edge(source, neighbor_debate[left_neighbor], RESPONSE_KEYS)
+        graph.create_edge(source, neighbor_debate[right_neighbor], RESPONSE_KEYS)
+
+    for node in full_debate:
+        graph.create_edge(node, full_vote, CONSENSUS_KEYS)
+    for node in neighbor_debate:
+        graph.create_edge(node, neighbor_vote, CONSENSUS_KEYS)
+
+    graph.create_edge(full_vote, compare, {"full_result": "fully-connected result"})
+    graph.create_edge(neighbor_vote, compare, {"neighbor_result": "neighbor-connected result"})
+    graph.edge_to_exit(compare, {"visual_summary": "visual explanation of both topologies"})
+
+    graph.build()
+    return graph
+
+
+def expected_edge_counts(*, num_agents: int) -> dict[str, int]:
+    return {
+        "fully_connected_directed_edges": num_agents * (num_agents - 1),
+        "neighbor_connected_directed_edges": num_agents * 2,
+    }
+
+
+def _prepare_question(input_data: dict) -> dict:
+    return {"question": input_data.get("question", "visualization only")}
+
+
+def _make_initial_forward(agent_name: str) -> Callable[[dict], dict]:
+    def forward(input_data: dict) -> dict:
+        return {"visible_response": f"{agent_name} initial answer to {input_data.get('question', '')}"}
+
+    return forward
+
+
+def _make_debate_forward(agent_name: str) -> Callable[[dict], dict]:
+    def forward(input_data: dict) -> dict:
+        return {"agent_answer": f"{agent_name} updated answer after reading visible neighbors"}
+
+    return forward
+
+
+def _consensus_forward(input_data: dict) -> dict:
+    return {"full_result": "full consensus", "neighbor_result": "neighbor consensus"}
+
+
+def _compare_forward(input_data: dict) -> dict:
+    return {
+        "visual_summary": (
+            "This graph visualizes the paper SOP: each agent is a node; "
+            "edges from R1 agents to R2 agents show which previous answers are visible."
+        )
+    }

--- a/applications/sparse_mad_reproduction/sparse_mad/datasets.py
+++ b/applications/sparse_mad_reproduction/sparse_mad/datasets.py
@@ -1,0 +1,36 @@
+﻿from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+BUILTIN_DATASETS = {
+    "mini_math": DATA_DIR / "mini_math.jsonl",
+}
+
+
+def load_jsonl_dataset(path: str | Path, *, limit: int | None = None) -> list[dict[str, str]]:
+    dataset_path = Path(path)
+    samples: list[dict[str, str]] = []
+    with dataset_path.open("r", encoding="utf-8-sig") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            record = json.loads(line)
+            if "question" not in record or "answer" not in record:
+                raise ValueError(f"Line {line_number} must contain question and answer fields")
+            samples.append({"question": str(record["question"]), "answer": str(record["answer"])})
+            if limit is not None and len(samples) >= limit:
+                break
+    return samples
+
+
+def load_builtin_dataset(name: str, *, limit: int | None = None) -> list[dict[str, str]]:
+    try:
+        path = BUILTIN_DATASETS[name]
+    except KeyError as exc:
+        available = ", ".join(sorted(BUILTIN_DATASETS))
+        raise ValueError(f"Unknown built-in dataset '{name}'. Available: {available}") from exc
+    return load_jsonl_dataset(path, limit=limit)

--- a/applications/sparse_mad_reproduction/sparse_mad/dry_runner.py
+++ b/applications/sparse_mad_reproduction/sparse_mad/dry_runner.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from sparse_mad.topology import build_topology
+from sparse_mad.voting import majority_vote
+
+
+def run_sparse_mad_dry(
+    *,
+    question: str,
+    num_agents: int = 6,
+    topology_type: str = "ring",
+    max_rounds: int = 3,
+    correct_answer: str = "42",
+) -> dict:
+    """Run a deterministic sparse MAD simulation without calling an LLM."""
+    if max_rounds < 1:
+        raise ValueError("max_rounds must be at least 1")
+
+    topology = build_topology(num_agents=num_agents, topology_type=topology_type)
+    responses_by_round: dict[int, dict[str, dict[str, str]]] = {}
+    visibility_by_round: dict[int, dict[str, list[str]]] = {}
+
+    responses_by_round[1] = _initial_responses(
+        question=question,
+        agents=topology.agents,
+        correct_answer=correct_answer,
+    )
+
+    for round_id in range(2, max_rounds + 1):
+        previous = responses_by_round[round_id - 1]
+        visibility_by_round[round_id] = topology.neighbors
+        responses_by_round[round_id] = {
+            agent: _debate_response(
+                agent=agent,
+                round_id=round_id,
+                question=question,
+                previous_answer=previous[agent]["answer"],
+                neighbor_answers=[previous[neighbor]["answer"] for neighbor in topology.neighbors[agent]],
+                correct_answer=correct_answer,
+            )
+            for agent in topology.agents
+        }
+
+    final_round = responses_by_round[max_rounds]
+    vote = majority_vote({agent: response["answer"] for agent, response in final_round.items()})
+
+    return {
+        "question": question,
+        "topology": topology.as_dict(),
+        "responses_by_round": responses_by_round,
+        "visibility_by_round": visibility_by_round,
+        "final_agent_answers": {agent: response["answer"] for agent, response in final_round.items()},
+        "final_answer": vote.final_answer,
+        "vote_summary": vote.vote_summary,
+        "token_cost": 0,
+    }
+
+
+def _initial_responses(*, question: str, agents: list[str], correct_answer: str) -> dict[str, dict[str, str]]:
+    responses = {}
+    for index, agent in enumerate(agents):
+        answer = correct_answer if index % 3 != 0 else str(int(correct_answer) - 1)
+        responses[agent] = {
+            "reasoning": f"{agent} initial dry reasoning for: {question}",
+            "answer": answer,
+        }
+    return responses
+
+
+def _debate_response(
+    *,
+    agent: str,
+    round_id: int,
+    question: str,
+    previous_answer: str,
+    neighbor_answers: list[str],
+    correct_answer: str,
+) -> dict[str, str]:
+    votes = neighbor_answers + [previous_answer]
+    answer = correct_answer if correct_answer in votes else previous_answer
+    return {
+        "reasoning": (
+            f"{agent} round {round_id} reviewed {len(neighbor_answers)} neighbor answers "
+            f"for: {question}"
+        ),
+        "answer": answer,
+    }

--- a/applications/sparse_mad_reproduction/sparse_mad/experiment.py
+++ b/applications/sparse_mad_reproduction/sparse_mad/experiment.py
@@ -1,0 +1,77 @@
+﻿from __future__ import annotations
+
+from sparse_mad.llm_runner import LLMClient, run_sparse_mad_llm
+from sparse_mad.metrics import is_correct, sum_token_cost
+
+
+def evaluate_topology(
+    *,
+    dataset: list[dict[str, str]],
+    client: LLMClient,
+    topology_type: str,
+    num_agents: int = 6,
+    max_rounds: int = 3,
+) -> dict:
+    if not dataset:
+        raise ValueError("dataset cannot be empty")
+
+    runs = []
+    correct_count = 0
+    for sample in dataset:
+        run = run_sparse_mad_llm(
+            question=sample["question"],
+            client=client,
+            num_agents=num_agents,
+            topology_type=topology_type,
+            max_rounds=max_rounds,
+        )
+        run["expected_answer"] = sample["answer"]
+        run["correct"] = is_correct(run["final_answer"], sample["answer"])
+        if run["correct"]:
+            correct_count += 1
+        runs.append(run)
+
+    total_count = len(dataset)
+    return {
+        "topology_type": topology_type,
+        "accuracy": correct_count / total_count,
+        "correct_count": correct_count,
+        "total_count": total_count,
+        "token_cost": sum_token_cost(runs),
+        "runs": runs,
+    }
+
+
+def compare_topologies(
+    *,
+    dataset: list[dict[str, str]],
+    client: LLMClient,
+    num_agents: int = 6,
+    max_rounds: int = 3,
+) -> dict:
+    fully_connected = evaluate_topology(
+        dataset=dataset,
+        client=client,
+        topology_type="fully_connected",
+        num_agents=num_agents,
+        max_rounds=max_rounds,
+    )
+    neighbor_connected = evaluate_topology(
+        dataset=dataset,
+        client=client,
+        topology_type="ring",
+        num_agents=num_agents,
+        max_rounds=max_rounds,
+    )
+
+    full_cost = fully_connected["token_cost"]
+    sparse_cost = neighbor_connected["token_cost"]
+    cost_saving = 0.0 if full_cost == 0 else 1 - sparse_cost / full_cost
+
+    return {
+        "fully_connected": fully_connected,
+        "neighbor_connected": neighbor_connected,
+        "cost_saving": cost_saving,
+        "num_agents": num_agents,
+        "max_rounds": max_rounds,
+    }

--- a/applications/sparse_mad_reproduction/sparse_mad/hf_datasets.py
+++ b/applications/sparse_mad_reproduction/sparse_mad/hf_datasets.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import os
+import random
+import re
+import tarfile
+import urllib.request
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import Any
+
+
+DatasetLoader = Callable[[str, str, str], Iterable[dict[str, Any]]]
+DEFAULT_DEEPMIND_MATH_SUBSET = "algebra__linear_1d_composed"
+_DEEPMIND_MATH_PARQUET_REVISION = "ce2e4d517071326389869c0a9e2cbaa123aee6cc"
+_DEEPMIND_MATH_ARCHIVE_URL = "https://storage.googleapis.com/mathematics-dataset/mathematics_dataset-v1.0.tar.gz"
+_DEEPMIND_SPLIT_DIRS = {
+    "test": ("interpolate",),
+    "train": ("train-easy", "train-medium", "train-hard"),
+}
+
+
+def load_hf_dataset(
+    dataset_name: str,
+    *,
+    split: str = "test",
+    limit: int | None = None,
+    math_subset: str = "algebra",
+    math_level: int | None = None,
+    deepmind_math_subset: str = DEFAULT_DEEPMIND_MATH_SUBSET,
+    shuffle: bool = False,
+    seed: int = 42,
+    loader: DatasetLoader | None = None,
+    deepmind_loader: DatasetLoader | None = None,
+) -> list[dict[str, str]]:
+    default_loader = loader or _load_dataset_from_huggingface
+    dataset_name = dataset_name.lower()
+
+    if dataset_name == "gsm8k":
+        records = default_loader("openai/gsm8k", "main", split)
+        samples = (_map_gsm8k_record(record) for record in records)
+        return _select_samples(samples, limit=limit, shuffle=shuffle, seed=seed)
+
+    if dataset_name in {"math", "hendrycks_math"}:
+        records = default_loader("EleutherAI/hendrycks_math", math_subset, split)
+        records = _filter_math_records_by_level(records, math_level)
+        samples = (_map_math_record(record) for record in records)
+        return _select_samples(samples, limit=limit, shuffle=shuffle, seed=seed)
+
+    if dataset_name in {"deepmind_math", "math_dataset"}:
+        records = (loader or deepmind_loader or _load_deepmind_math_from_huggingface)(
+            "deepmind/math_dataset", deepmind_math_subset, split
+        )
+        samples = (_map_deepmind_math_record(record) for record in records)
+        return _select_samples(samples, limit=limit, shuffle=shuffle, seed=seed)
+
+    raise ValueError("dataset_name must be 'gsm8k', 'math', or 'deepmind_math'")
+
+
+def parse_gsm8k_answer(answer_text: str) -> str:
+    if "####" in answer_text:
+        answer = answer_text.rsplit("####", 1)[1]
+    else:
+        numbers = re.findall(r"-?\d+(?:\.\d+)?", answer_text)
+        answer = numbers[-1] if numbers else answer_text
+    return _clean_answer(answer)
+
+
+def parse_math_answer(solution: str) -> str:
+    boxed = re.findall(r"\\boxed\{([^{}]+)\}", solution)
+    if boxed:
+        return _clean_answer(boxed[-1])
+
+    numbers = re.findall(r"-?\d+(?:\.\d+)?", solution)
+    if numbers:
+        return _clean_answer(numbers[-1])
+    return _clean_answer(solution)
+
+
+def _map_gsm8k_record(record: dict[str, Any]) -> dict[str, str]:
+    return {
+        "question": str(record["question"]),
+        "answer": parse_gsm8k_answer(str(record["answer"])),
+    }
+
+
+def _map_math_record(record: dict[str, Any]) -> dict[str, str]:
+    return {
+        "question": str(record["problem"]),
+        "answer": parse_math_answer(str(record["solution"])),
+    }
+
+
+def _map_deepmind_math_record(record: dict[str, Any]) -> dict[str, str]:
+    return {
+        "question": str(record["question"]).strip(),
+        "answer": _clean_answer(str(record["answer"])),
+    }
+
+
+def _filter_math_records_by_level(records: Iterable[dict[str, Any]], math_level: int | None):
+    if math_level is None:
+        yield from records
+        return
+
+    for record in records:
+        if _parse_math_level(record.get("level")) == math_level:
+            yield record
+
+
+def _parse_math_level(level: Any) -> int | None:
+    if level is None:
+        return None
+    match = re.search(r"\d+", str(level))
+    return int(match.group(0)) if match else None
+
+
+def _select_samples(
+    samples: Iterable[dict[str, str]],
+    *,
+    limit: int | None,
+    shuffle: bool,
+    seed: int,
+) -> list[dict[str, str]]:
+    if shuffle:
+        result = list(samples)
+        random.Random(seed).shuffle(result)
+        return result[:limit] if limit is not None else result
+    return _take_limit(samples, limit)
+
+
+def _take_limit(samples: Iterable[dict[str, str]], limit: int | None) -> list[dict[str, str]]:
+    result: list[dict[str, str]] = []
+    for sample in samples:
+        result.append(sample)
+        if limit is not None and len(result) >= limit:
+            break
+    return result
+
+
+def _load_deepmind_math_from_huggingface(path: str, name: str, split: str):
+    try:
+        return _load_deepmind_math_from_converted_parquet(path, name, split)
+    except Exception as parquet_exc:
+        try:
+            return _load_deepmind_math_from_original_archive(path, name, split)
+        except Exception as archive_exc:
+            raise RuntimeError(
+                "Could not load DeepMind Mathematics Dataset. Tried Hugging Face converted parquet "
+                "and the original DeepMind archive."
+            ) from archive_exc
+
+
+def _load_deepmind_math_from_converted_parquet(path: str, name: str, split: str):
+    try:
+        from datasets import load_dataset
+    except ImportError as exc:
+        raise RuntimeError(
+            "The Hugging Face datasets package is not installed. "
+            "Run `python -m pip install datasets` or reinstall requirements.txt."
+        ) from exc
+
+    parquet_url = _deepmind_math_parquet_url(path, name, split)
+    return load_dataset("parquet", data_files={split: parquet_url}, split=split)
+
+
+def _deepmind_math_parquet_url(path: str, name: str, split: str) -> str:
+    return f"hf://datasets/{path}@{_DEEPMIND_MATH_PARQUET_REVISION}/{name}/{split}-*.parquet"
+
+
+def _load_deepmind_math_from_original_archive(path: str, name: str, split: str):
+    del path
+    archive_path = _ensure_deepmind_math_archive()
+    return _iter_deepmind_math_tar_records(archive_path, name, split)
+
+
+def _ensure_deepmind_math_archive() -> Path:
+    cache_root = Path(os.environ.get("SPARSE_MAD_CACHE_DIR", Path.home() / ".cache" / "sparse_mad"))
+    cache_root.mkdir(parents=True, exist_ok=True)
+    archive_path = cache_root / "mathematics_dataset-v1.0.tar.gz"
+    if not archive_path.exists():
+        urllib.request.urlretrieve(_DEEPMIND_MATH_ARCHIVE_URL, archive_path)
+    return archive_path
+
+
+def _iter_deepmind_math_tar_records(archive_path: str | Path, subset: str, split: str):
+    split_dirs = _DEEPMIND_SPLIT_DIRS.get(split)
+    if split_dirs is None:
+        available = ", ".join(sorted(_DEEPMIND_SPLIT_DIRS))
+        raise ValueError(f"DeepMind Mathematics split must be one of: {available}")
+
+    expected_members = {
+        f"mathematics_dataset-v1.0/{split_dir}/{subset}.txt" for split_dir in split_dirs
+    }
+    found_member = False
+    with tarfile.open(archive_path, "r:gz") as archive:
+        for member in archive:
+            if member.name not in expected_members:
+                continue
+            found_member = True
+            extracted = archive.extractfile(member)
+            if extracted is None:
+                continue
+            yield from _iter_question_answer_lines(extracted)
+
+    if not found_member:
+        expected = ", ".join(sorted(expected_members))
+        raise ValueError(f"DeepMind Mathematics subset file not found in archive: {expected}")
+
+
+def _iter_question_answer_lines(handle):
+    question: str | None = None
+    for raw_line in handle:
+        line = raw_line.decode("utf-8").strip()
+        if not line:
+            continue
+        if question is None:
+            question = line
+        else:
+            yield {"question": question, "answer": line}
+            question = None
+
+
+def _load_dataset_from_huggingface(path: str, name: str, split: str):
+    try:
+        from datasets import load_dataset
+    except ImportError as exc:
+        raise RuntimeError(
+            "The Hugging Face datasets package is not installed. "
+            "Run `python -m pip install datasets` or reinstall requirements.txt."
+        ) from exc
+
+    return load_dataset(path, name, split=split)
+
+
+def _clean_answer(answer: str) -> str:
+    return answer.strip().replace(",", "").strip("$ ").rstrip(".")

--- a/applications/sparse_mad_reproduction/sparse_mad/llm_runner.py
+++ b/applications/sparse_mad_reproduction/sparse_mad/llm_runner.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import os
+import re
+from typing import Protocol
+
+from openai import OpenAI
+
+from sparse_mad.metrics import estimate_messages_tokens
+from sparse_mad.topology import build_topology
+from sparse_mad.voting import majority_vote
+
+
+class LLMClient(Protocol):
+    def complete(self, messages: list[dict[str, str]]) -> str:
+        ...
+
+
+class OpenAICompatibleClient:
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        model_name: str | None = None,
+        temperature: float = 0.25,
+    ) -> None:
+        self.model_name = model_name or os.getenv("OPENAI_MODEL_NAME") or os.getenv("MODEL_NAME", "gpt-4o-mini")
+        self.temperature = temperature
+        self.client = OpenAI(
+            api_key=api_key or os.getenv("OPENAI_API_KEY"),
+            base_url=base_url or os.getenv("OPENAI_BASE_URL"),
+        )
+
+    def complete(self, messages: list[dict[str, str]]) -> str:
+        response = self.client.chat.completions.create(
+            model=self.model_name,
+            messages=messages,
+            temperature=self.temperature,
+        )
+        return response.choices[0].message.content or ""
+
+
+def run_sparse_mad_llm(
+    *,
+    question: str,
+    client: LLMClient,
+    num_agents: int = 6,
+    topology_type: str = "ring",
+    max_rounds: int = 3,
+) -> dict:
+    if max_rounds < 1:
+        raise ValueError("max_rounds must be at least 1")
+
+    topology = build_topology(num_agents=num_agents, topology_type=topology_type)
+    responses_by_round: dict[int, dict[str, dict[str, str]]] = {}
+    visibility_by_round: dict[int, dict[str, list[str]]] = {}
+
+    responses_by_round[1] = {
+        agent: _call_initial_agent(client=client, agent=agent, question=question)
+        for agent in topology.agents
+    }
+
+    for round_id in range(2, max_rounds + 1):
+        previous = responses_by_round[round_id - 1]
+        visibility_by_round[round_id] = topology.neighbors
+        responses_by_round[round_id] = {
+            agent: _call_debate_agent(
+                client=client,
+                agent=agent,
+                question=question,
+                round_id=round_id,
+                own_previous=previous[agent],
+                neighbor_responses={neighbor: previous[neighbor] for neighbor in topology.neighbors[agent]},
+            )
+            for agent in topology.agents
+        }
+
+    final_round = responses_by_round[max_rounds]
+    vote = majority_vote({agent: response["answer"] for agent, response in final_round.items()})
+    token_cost = sum(
+        response["input_tokens"]
+        for round_responses in responses_by_round.values()
+        for response in round_responses.values()
+    )
+
+    return {
+        "question": question,
+        "topology": topology.as_dict(),
+        "responses_by_round": responses_by_round,
+        "visibility_by_round": visibility_by_round,
+        "final_agent_answers": {agent: response["answer"] for agent, response in final_round.items()},
+        "final_answer": vote.final_answer,
+        "vote_summary": vote.vote_summary,
+        "token_cost": token_cost,
+    }
+
+
+def extract_answer(text: str) -> str:
+    final_match = re.search(r"FINAL\s*:\s*([^\n]+)", text, flags=re.IGNORECASE)
+    if final_match:
+        return _clean_answer(final_match.group(1))
+
+    boxed_match = re.search(r"\\boxed\{([^}]+)\}", text)
+    if boxed_match:
+        return _clean_answer(boxed_match.group(1))
+
+    numbers = re.findall(r"-?\d+(?:\.\d+)?", text)
+    if numbers:
+        return numbers[-1]
+
+    return _clean_answer(text)
+
+
+def _call_initial_agent(*, client: LLMClient, agent: str, question: str) -> dict[str, str | int]:
+    messages = [
+        {"role": "system", "content": _system_prompt()},
+        {
+            "role": "user",
+            "content": (
+                f"You are {agent}. Solve the following problem independently.\n\n"
+                f"Problem: {question}\n\n"
+                "Give concise reasoning and end with `FINAL: <answer>`."
+            ),
+        },
+    ]
+    input_tokens = estimate_messages_tokens(messages)
+    content = client.complete(messages)
+    return {"reasoning": content, "answer": extract_answer(content), "input_tokens": input_tokens}
+
+
+def _call_debate_agent(
+    *,
+    client: LLMClient,
+    agent: str,
+    question: str,
+    round_id: int,
+    own_previous: dict[str, str],
+    neighbor_responses: dict[str, dict[str, str]],
+) -> dict[str, str | int]:
+    references = "\n\n".join(
+        f"{neighbor} previous response:\n{response['reasoning']}"
+        for neighbor, response in neighbor_responses.items()
+    )
+    messages = [
+        {"role": "system", "content": _system_prompt()},
+        {
+            "role": "user",
+            "content": (
+                f"You are {agent} in debate round {round_id}.\n\n"
+                f"Problem: {question}\n\n"
+                f"Your previous response:\n{own_previous['reasoning']}\n\n"
+                f"Neighbor responses visible to you:\n{references}\n\n"
+                "Use only your own previous response and the visible neighbor responses. "
+                "Update your answer if needed. End with `FINAL: <answer>`."
+            ),
+        },
+    ]
+    input_tokens = estimate_messages_tokens(messages)
+    content = client.complete(messages)
+    return {"reasoning": content, "answer": extract_answer(content), "input_tokens": input_tokens}
+
+
+def _system_prompt() -> str:
+    return (
+        "You are a careful reasoning agent in a multi-agent debate system. "
+        "Keep reasoning concise. Always finish with exactly one line: FINAL: <answer>."
+    )
+
+
+def _clean_answer(answer: str) -> str:
+    return answer.strip().strip("`").strip().rstrip(".")
+

--- a/applications/sparse_mad_reproduction/sparse_mad/metrics.py
+++ b/applications/sparse_mad_reproduction/sparse_mad/metrics.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from decimal import Decimal, InvalidOperation
+
+
+_NORMALIZE_RE = re.compile(r"[^a-zA-Z0-9.\-]+")
+_NUMBER_RE = re.compile(r"-?\d[\d,]*(?:\.\d+)?")
+_TIME_RE = re.compile(r"\d{1,2}:\d{2}")
+_TOKEN_RE = re.compile(r"\w+|[^\w\s]", flags=re.UNICODE)
+
+
+def estimate_messages_tokens(messages: list[dict[str, str]], *, model_name: str = "gpt-4o-mini") -> int:
+    text = "\n".join(f"{message.get('role', '')}: {message.get('content', '')}" for message in messages)
+    return max(1, len(_TOKEN_RE.findall(text)))
+
+
+def normalize_answer(answer: str) -> str:
+    text = str(answer).lower().strip().strip("`").strip()
+    text = text.rstrip(".")
+    if _TIME_RE.fullmatch(text):
+        return text
+
+    number_matches = _NUMBER_RE.findall(text.replace("$", ""))
+    if number_matches:
+        return _normalize_number(number_matches[-1])
+
+    return _NORMALIZE_RE.sub("", text).strip().rstrip(".")
+
+
+def _normalize_number(value: str) -> str:
+    value = value.replace(",", "")
+    try:
+        number = Decimal(value)
+    except InvalidOperation:
+        return value
+    if number == number.to_integral_value():
+        return str(int(number))
+    return format(number.normalize(), "f").rstrip("0").rstrip(".")
+
+
+def is_correct(predicted: str, expected: str) -> bool:
+    return normalize_answer(predicted) == normalize_answer(expected)
+
+
+def sum_token_cost(runs: Iterable[dict]) -> int:
+    return sum(int(run.get("token_cost") or 0) for run in runs)

--- a/applications/sparse_mad_reproduction/sparse_mad/topology.py
+++ b/applications/sparse_mad_reproduction/sparse_mad/topology.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Topology:
+    agents: list[str]
+    edges: list[tuple[str, str]]
+    neighbors: dict[str, list[str]]
+    density: float
+
+    def as_dict(self) -> dict:
+        return {
+            "agents": self.agents,
+            "edges": self.edges,
+            "neighbors": self.neighbors,
+            "density": self.density,
+        }
+
+
+def graph_density(num_agents: int, edge_count: int) -> float:
+    if num_agents < 2:
+        raise ValueError("num_agents must be at least 2")
+    return 2 * edge_count / (num_agents * (num_agents - 1))
+
+
+def build_topology(num_agents: int, topology_type: str) -> Topology:
+    if num_agents < 2:
+        raise ValueError("num_agents must be at least 2")
+
+    agents = [f"Agent_{index}" for index in range(1, num_agents + 1)]
+    topology_type = topology_type.lower()
+
+    if topology_type in {"ring", "neighbor_connected", "neighbor"}:
+        edges = [(agents[index], agents[(index + 1) % num_agents]) for index in range(num_agents)]
+    elif topology_type in {"fully_connected", "full"}:
+        edges = [
+            (agents[left], agents[right])
+            for left in range(num_agents)
+            for right in range(left + 1, num_agents)
+        ]
+    else:
+        raise ValueError(f"Unsupported topology_type: {topology_type}")
+
+    neighbors = {agent: [] for agent in agents}
+    for left, right in edges:
+        neighbors[left].append(right)
+        neighbors[right].append(left)
+
+    return Topology(
+        agents=agents,
+        edges=edges,
+        neighbors=neighbors,
+        density=graph_density(num_agents, len(edges)),
+    )

--- a/applications/sparse_mad_reproduction/sparse_mad/visual_workflow.py
+++ b/applications/sparse_mad_reproduction/sparse_mad/visual_workflow.py
@@ -1,0 +1,147 @@
+﻿from __future__ import annotations
+
+from sparse_mad.experiment import evaluate_topology
+from sparse_mad.llm_runner import LLMClient
+
+
+VISUAL_INPUT_KEYS = {
+    "dataset": "list of samples with question and answer",
+    "num_agents": "number of debate agents",
+    "max_rounds": "total debate rounds",
+}
+
+PREPARED_KEYS = {
+    **VISUAL_INPUT_KEYS,
+    "experiment_name": "name for this topology comparison experiment",
+}
+
+FULL_TOPOLOGY_KEYS = {
+    **PREPARED_KEYS,
+    "full_topology_type": "fully-connected topology label",
+}
+
+FULL_RESULT_KEYS = {
+    **PREPARED_KEYS,
+    "full_topology_type": "fully-connected topology label",
+    "fully_connected": "evaluation result for D=1 topology",
+}
+
+NEIGHBOR_TOPOLOGY_KEYS = {
+    **FULL_RESULT_KEYS,
+    "neighbor_topology_type": "neighbor-connected topology label",
+}
+
+BOTH_RESULT_KEYS = {
+    **FULL_RESULT_KEYS,
+    "neighbor_topology_type": "neighbor-connected topology label",
+    "neighbor_connected": "evaluation result for sparse neighbor topology",
+}
+
+METRIC_KEYS = {
+    **BOTH_RESULT_KEYS,
+    "cost_saving": "relative sparse cost saving against fully connected",
+}
+
+REPORT_KEYS = {
+    **METRIC_KEYS,
+    "report": "human-readable experiment report",
+}
+
+
+def build_visual_comparison_graph(*, client: LLMClient):
+    """Build a visual, fine-grained MASFactory graph for the paper SOP."""
+    from masfactory import CustomNode, RootGraph
+
+    graph = RootGraph(name="visual_sparse_mad_paper_sop")
+
+    prepare_dataset = graph.create_node(CustomNode, name="PrepareDataset", forward=_prepare_dataset)
+    build_full_topology = graph.create_node(CustomNode, name="BuildFullTopology_D_equals_1", forward=_build_full_topology)
+    run_full_mad = graph.create_node(
+        CustomNode,
+        name="RunFullyConnectedMAD",
+        forward=lambda input_data: _run_full_mad(input_data, client=client),
+    )
+    build_neighbor_topology = graph.create_node(
+        CustomNode,
+        name="BuildNeighborTopology",
+        forward=_build_neighbor_topology,
+    )
+    run_neighbor_mad = graph.create_node(
+        CustomNode,
+        name="RunNeighborConnectedMAD",
+        forward=lambda input_data: _run_neighbor_mad(input_data, client=client),
+    )
+    compute_cost_saving = graph.create_node(CustomNode, name="ComputeAccuracyAndCostSaving", forward=_compute_cost_saving)
+    format_report = graph.create_node(CustomNode, name="FormatExperimentReport", forward=_format_report)
+
+    graph.edge_from_entry(prepare_dataset, VISUAL_INPUT_KEYS)
+    graph.create_edge(prepare_dataset, build_full_topology, PREPARED_KEYS)
+    graph.create_edge(build_full_topology, run_full_mad, FULL_TOPOLOGY_KEYS)
+    graph.create_edge(run_full_mad, build_neighbor_topology, FULL_RESULT_KEYS)
+    graph.create_edge(build_neighbor_topology, run_neighbor_mad, NEIGHBOR_TOPOLOGY_KEYS)
+    graph.create_edge(run_neighbor_mad, compute_cost_saving, BOTH_RESULT_KEYS)
+    graph.create_edge(compute_cost_saving, format_report, METRIC_KEYS)
+    graph.edge_to_exit(format_report, REPORT_KEYS)
+
+    graph.build()
+    return graph
+
+
+def _prepare_dataset(input_data: dict) -> dict:
+    return {
+        "dataset": input_data["dataset"],
+        "num_agents": int(input_data.get("num_agents", 4)),
+        "max_rounds": int(input_data.get("max_rounds", 2)),
+        "experiment_name": "Sparse MAD comparison: fully connected vs neighbor connected",
+    }
+
+
+def _build_full_topology(input_data: dict) -> dict:
+    return {**input_data, "full_topology_type": "fully_connected"}
+
+
+def _run_full_mad(input_data: dict, *, client: LLMClient) -> dict:
+    fully_connected = evaluate_topology(
+        dataset=input_data["dataset"],
+        client=client,
+        topology_type=input_data["full_topology_type"],
+        num_agents=input_data["num_agents"],
+        max_rounds=input_data["max_rounds"],
+    )
+    return {**input_data, "fully_connected": fully_connected}
+
+
+def _build_neighbor_topology(input_data: dict) -> dict:
+    return {**input_data, "neighbor_topology_type": "ring"}
+
+
+def _run_neighbor_mad(input_data: dict, *, client: LLMClient) -> dict:
+    neighbor_connected = evaluate_topology(
+        dataset=input_data["dataset"],
+        client=client,
+        topology_type=input_data["neighbor_topology_type"],
+        num_agents=input_data["num_agents"],
+        max_rounds=input_data["max_rounds"],
+    )
+    return {**input_data, "neighbor_connected": neighbor_connected}
+
+
+def _compute_cost_saving(input_data: dict) -> dict:
+    full_cost = input_data["fully_connected"]["token_cost"]
+    neighbor_cost = input_data["neighbor_connected"]["token_cost"]
+    cost_saving = 0.0 if full_cost == 0 else 1 - neighbor_cost / full_cost
+    return {**input_data, "cost_saving": cost_saving}
+
+
+def _format_report(input_data: dict) -> dict:
+    full = input_data["fully_connected"]
+    neighbor = input_data["neighbor_connected"]
+    report = (
+        "Sparse MAD comparison report\n"
+        f"Experiment: {input_data['experiment_name']}\n"
+        f"Agents: {input_data['num_agents']} | Rounds: {input_data['max_rounds']}\n"
+        f"Fully-connected MAD: accuracy={full['accuracy']:.3f}, cost={full['token_cost']}\n"
+        f"Neighbor-connected MAD: accuracy={neighbor['accuracy']:.3f}, cost={neighbor['token_cost']}\n"
+        f"Cost saving: {input_data['cost_saving']:.1%}"
+    )
+    return {**input_data, "report": report}

--- a/applications/sparse_mad_reproduction/sparse_mad/voting.py
+++ b/applications/sparse_mad_reproduction/sparse_mad/voting.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class VoteResult:
+    final_answer: str
+    vote_summary: dict[str, int]
+
+
+def majority_vote(agent_answers: dict[str, str]) -> VoteResult:
+    if not agent_answers:
+        raise ValueError("agent_answers cannot be empty")
+
+    counts = Counter(agent_answers.values())
+    final_answer, _count = sorted(counts.items(), key=lambda item: (-item[1], item[0]))[0]
+
+    return VoteResult(
+        final_answer=final_answer,
+        vote_summary=dict(sorted(counts.items())),
+    )

--- a/applications/sparse_mad_reproduction/sparse_mad/workflow.py
+++ b/applications/sparse_mad_reproduction/sparse_mad/workflow.py
@@ -1,0 +1,186 @@
+﻿from __future__ import annotations
+
+from sparse_mad.dry_runner import run_sparse_mad_dry
+from sparse_mad.experiment import compare_topologies
+from sparse_mad.llm_runner import LLMClient, run_sparse_mad_llm
+
+
+WORKFLOW_KEYS = {
+    "question": "input task question",
+    "num_agents": "number of debate agents",
+    "topology_type": "communication topology type",
+    "max_rounds": "total debate rounds",
+    "correct_answer": "optional expected answer for dry-run simulation",
+}
+
+LLM_WORKFLOW_KEYS = {
+    "question": "input task question",
+    "num_agents": "number of debate agents",
+    "topology_type": "communication topology type",
+    "max_rounds": "total debate rounds",
+}
+
+COMPARISON_KEYS = {
+    "dataset": "list of samples with question and answer",
+    "num_agents": "number of debate agents",
+    "max_rounds": "total debate rounds",
+}
+
+RESULT_KEYS = {
+    "question": "input task question",
+    "topology": "communication topology information",
+    "responses_by_round": "all agent responses grouped by round",
+    "visibility_by_round": "neighbor visibility for debate rounds",
+    "final_agent_answers": "final answer from each agent",
+    "final_answer": "majority-vote final answer",
+    "vote_summary": "answer vote counts",
+    "token_cost": "tracked input token cost",
+}
+
+EXIT_KEYS = {
+    **RESULT_KEYS,
+    "summary": "human-readable run summary",
+}
+
+COMPARISON_RESULT_KEYS = {
+    "fully_connected": "evaluation result for D=1 topology",
+    "neighbor_connected": "evaluation result for sparse neighbor topology",
+    "cost_saving": "relative sparse cost saving against fully connected",
+    "num_agents": "number of debate agents",
+    "max_rounds": "total debate rounds",
+}
+
+COMPARISON_EXIT_KEYS = {
+    **COMPARISON_RESULT_KEYS,
+    "summary": "human-readable comparison summary",
+}
+
+
+def build_sparse_mad_dry_graph():
+    from masfactory import CustomNode, RootGraph
+
+    graph = RootGraph(name="sparse_mad_dry_graph")
+
+    prepare = graph.create_node(CustomNode, name="PrepareQuestion", forward=_prepare_question)
+    run_debate = graph.create_node(CustomNode, name="RunSparseMADDry", forward=_run_sparse_mad_dry)
+    format_result = graph.create_node(CustomNode, name="FormatResult", forward=_format_result)
+
+    graph.edge_from_entry(prepare, WORKFLOW_KEYS)
+    graph.create_edge(prepare, run_debate, WORKFLOW_KEYS)
+    graph.create_edge(run_debate, format_result, RESULT_KEYS)
+    graph.edge_to_exit(format_result, EXIT_KEYS)
+
+    graph.build()
+    return graph
+
+
+def build_sparse_mad_llm_graph(*, client: LLMClient):
+    from masfactory import CustomNode, RootGraph
+
+    graph = RootGraph(name="sparse_mad_llm_graph")
+
+    prepare = graph.create_node(CustomNode, name="PrepareQuestion", forward=_prepare_question)
+    run_debate = graph.create_node(
+        CustomNode,
+        name="RunSparseMADLLM",
+        forward=lambda input_data: _run_sparse_mad_llm(input_data, client=client),
+    )
+    format_result = graph.create_node(CustomNode, name="FormatResult", forward=_format_result)
+
+    graph.edge_from_entry(prepare, LLM_WORKFLOW_KEYS)
+    graph.create_edge(prepare, run_debate, LLM_WORKFLOW_KEYS)
+    graph.create_edge(run_debate, format_result, RESULT_KEYS)
+    graph.edge_to_exit(format_result, EXIT_KEYS)
+
+    graph.build()
+    return graph
+
+
+def build_sparse_mad_comparison_graph(*, client: LLMClient):
+    from masfactory import CustomNode, RootGraph
+
+    graph = RootGraph(name="sparse_mad_topology_comparison_graph")
+
+    prepare = graph.create_node(CustomNode, name="PrepareComparison", forward=_prepare_comparison)
+    run_comparison = graph.create_node(
+        CustomNode,
+        name="RunTopologyComparison",
+        forward=lambda input_data: _run_topology_comparison(input_data, client=client),
+    )
+    format_result = graph.create_node(CustomNode, name="FormatComparison", forward=_format_comparison)
+
+    graph.edge_from_entry(prepare, COMPARISON_KEYS)
+    graph.create_edge(prepare, run_comparison, COMPARISON_KEYS)
+    graph.create_edge(run_comparison, format_result, COMPARISON_RESULT_KEYS)
+    graph.edge_to_exit(format_result, COMPARISON_EXIT_KEYS)
+
+    graph.build()
+    return graph
+
+
+def _prepare_question(input_data: dict) -> dict:
+    return {
+        "question": input_data["question"],
+        "num_agents": int(input_data.get("num_agents", 6)),
+        "topology_type": input_data.get("topology_type", "ring"),
+        "max_rounds": int(input_data.get("max_rounds", 3)),
+        "correct_answer": str(input_data.get("correct_answer", "42")),
+    }
+
+
+def _prepare_comparison(input_data: dict) -> dict:
+    return {
+        "dataset": input_data["dataset"],
+        "num_agents": int(input_data.get("num_agents", 6)),
+        "max_rounds": int(input_data.get("max_rounds", 3)),
+    }
+
+
+def _run_sparse_mad_dry(input_data: dict) -> dict:
+    return run_sparse_mad_dry(
+        question=input_data["question"],
+        num_agents=input_data["num_agents"],
+        topology_type=input_data["topology_type"],
+        max_rounds=input_data["max_rounds"],
+        correct_answer=input_data["correct_answer"],
+    )
+
+
+def _run_sparse_mad_llm(input_data: dict, *, client: LLMClient) -> dict:
+    return run_sparse_mad_llm(
+        question=input_data["question"],
+        client=client,
+        num_agents=input_data["num_agents"],
+        topology_type=input_data["topology_type"],
+        max_rounds=input_data["max_rounds"],
+    )
+
+
+def _run_topology_comparison(input_data: dict, *, client: LLMClient) -> dict:
+    return compare_topologies(
+        dataset=input_data["dataset"],
+        client=client,
+        num_agents=input_data["num_agents"],
+        max_rounds=input_data["max_rounds"],
+    )
+
+
+def _format_result(input_data: dict) -> dict:
+    topology = input_data["topology"]
+    summary = (
+        f"Final answer: {input_data['final_answer']} | "
+        f"topology density: {topology['density']:.3f} | "
+        f"votes: {input_data['vote_summary']}"
+    )
+    return {**input_data, "summary": summary}
+
+
+def _format_comparison(input_data: dict) -> dict:
+    full = input_data["fully_connected"]
+    neighbor = input_data["neighbor_connected"]
+    summary = (
+        f"Fully-connected accuracy={full['accuracy']:.3f}, cost={full['token_cost']} | "
+        f"Neighbor-connected accuracy={neighbor['accuracy']:.3f}, cost={neighbor['token_cost']} | "
+        f"cost saving={input_data['cost_saving']:.1%}"
+    )
+    return {**input_data, "summary": summary}


### PR DESCRIPTION
This PR adds a MASFactory-based reproduction application for the paper "Improving Multi-Agent Debate with Sparse Communication Topology".

It demonstrates:
- Modeling the paper SOP as a MASFactory Node / Edge / Graph workflow
- Visualizing fully connected and sparse agent communication topologies
- Running fully connected MAD vs neighbor-connected sparse MAD
- Comparing accuracy and estimated input-token cost
- Loading mini_math, GSM8K, Hendrycks MATH, and DeepMind Mathematics Dataset
- Supporting hard MATH evaluation with `--math-level`, `--shuffle`, and `--seed`
- Unit tests for topology, workflows, dataset mapping, voting, metrics, and runners

Tested with:

```powershell
python -m pytest tests
