### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Documentation: https://docs.masfactory.dev/
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=BUPT-GAMMA/MASFactory&type=Date)](https://star-history.com/#BUPT-GAMMA/MASFactory&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=BUPT-GAMMA/MASFactory&type=Date)](https://star-history.dera.page/#BUPT-GAMMA/MASFactory&Date)
 
 ## 📬 Contact
 QQ: 2157069383

--- a/README.zh.md
+++ b/README.zh.md
@@ -372,7 +372,7 @@ python applications/camel/main.py "Create a sample adder by using python"
 
 ## ⭐ Star 趋势
 
-[![Star History Chart](https://api.star-history.com/svg?repos=BUPT-GAMMA/MASFactory&type=Date)](https://star-history.com/#BUPT-GAMMA/MASFactory&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=BUPT-GAMMA/MASFactory&type=Date)](https://star-history.dera.page/#BUPT-GAMMA/MASFactory&Date)
 
 ## 📬 交流讨论组
 QQ: 2157069383


### PR DESCRIPTION
The star history chart is currently broken because of GitHub stargazer API restrictions. This change updates the chart in both README and README.zh to use an alternative that requires no API token, restoring the star history display.